### PR TITLE
remove chained ads in case of regex-filter hit

### DIFF
--- a/lib/interface.d.ts
+++ b/lib/interface.d.ts
@@ -37,6 +37,10 @@ export interface IArguments {
      */
     silent: boolean;
     /**
+     * Attempt to remove chained ads (s su sub subt...)
+     */
+    chainedads: boolean;
+    /**
      * Expects directory. This will clean multiple files across multiple directories and subdirectories.
      * Use the depth parameter to limit how many directories deep subclean will look.
      */

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ class SubClean {
             silent: argv.silent || argv.s || false,
             version: argv.version || argv.v || false,
             update: argv.update || false,
+            chainedads: argv.a || argv.chainedads || false,
             sweep: argv.sweep || '',
             depth: argv.depth ?? 10,
             ne: argv['ne'] || false,
@@ -308,8 +309,11 @@ class SubClean {
                 // For debugging
                 this.nodes_count += nodes.length;
 
+                //Chained ads flag
+                const checkForChainedAds:boolean = item.chainedads;
+
                 // Remove ads
-                nodes.forEach((node: any, index) => {
+                nodes.forEach((node: any, index:number) => {
                     this.blacklist.forEach((mark: any) => {
                         let regex = null;
                         this.actions_count++;
@@ -322,8 +326,9 @@ class SubClean {
                                 this.log(`[Match] Advertising found in node ${index + 1} (${mark})`);
                                 if (this.args.debug) this.log('[Line] ' + nodeText);
                                 hits++;
-                                if(index === 0) node.data.text = '';
-                                else{
+                                node.data.text = '';
+                                
+                                if (index > 0 && checkForChainedAds){
                                     const previousNodeText = (nodes[index-1].data as Cue).text;
                                     if(nodeText.includes(previousNodeText)){
                                         for(let i=index-1; i>0; i--){

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -37,6 +37,10 @@ export interface IArguments {
      */
     silent: boolean;
     /**
+     * Attempt to remove chained ads (s su sub subt...)
+     */
+     chainedads: boolean;
+    /**
      * Expects directory. This will clean multiple files across multiple directories and subdirectories.
      * Use the depth parameter to limit how many directories deep subclean will look.
      */


### PR DESCRIPTION
I'm not really familiar with subtitles ads so I was working under the assumption that only the regex based filter yields a hit of chained nodes, so my solution is applied only for those cases.

I can also expand it to rest of the cases, my initial thought is to hold a node hit index array, and apply the fix for all those indexes right after the blacklist loop.