### PR TITLE
Added Node.js Module Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,19 @@
 {
     "name": "subclean",
-    "version": "1.5.0",
+    "version": "1.5.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "subclean",
-            "version": "1.5.0",
+            "version": "1.5.3",
+            "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
                 "@types/subtitle": "^2.0.3",
                 "minimist": "^1.2.5",
                 "subtitle": "^4.0.1",
+                "typescript": "^4.2.4",
                 "update-notifier": "^5.1.0"
             },
             "bin": {
@@ -23,8 +25,7 @@
                 "eslint": "^8.12.0",
                 "fs-extra": "^9.1.0",
                 "pkg": "^4.5.1",
-                "prettier": "^2.3.0",
-                "typescript": "^4.2.4"
+                "prettier": "^2.3.0"
             }
         },
         "node_modules/@babel/parser": {
@@ -3484,7 +3485,6 @@
             "version": "4.2.4",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
             "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
-            "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -6357,8 +6357,7 @@
         "typescript": {
             "version": "4.2.4",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-            "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
-            "dev": true
+            "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg=="
         },
         "uid2": {
             "version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
         "test": "ts-node src/index.ts --sweep \"samples\" --uf=appdata --debug --ne",
         "test-update": "ts-node src/index.ts --update",
         "build": "tsc && pkg . && npm run tidy",
-        "tidy": "ts-node postbuild.ts"
+        "tidy": "ts-node postbuild.ts",
+        "postinstall": "tsc"
     },
     "keywords": [
         "subtitle",
@@ -26,7 +27,8 @@
         "@types/subtitle": "^2.0.3",
         "minimist": "^1.2.5",
         "subtitle": "^4.0.1",
-        "update-notifier": "^5.1.0"
+        "update-notifier": "^5.1.0",
+        "typescript": "^4.2.4"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.17.0",
@@ -34,8 +36,7 @@
         "eslint": "^8.12.0",
         "fs-extra": "^9.1.0",
         "pkg": "^4.5.1",
-        "prettier": "^2.3.0",
-        "typescript": "^4.2.4"
+        "prettier": "^2.3.0"
     },
     "pkg": {
         "out-path": "./bin/",


### PR DESCRIPTION
I tried my luck at adding node.js module support, there is probably a better way to do this but it does work.

Example usage:
```javascript
const fs = require('fs');
const SubClean = require("subclean");

const cleanSubs = (srtData) => {
  const cleaner = new SubClean();
  return cleaner.module(srtData, { ne: true });
}

const init = async (srtPath, outputPath) => {
  const srtData = fs.readFileSync(srtPath).toString()
  const srtDataNoAds = await cleanSubs(srtData)
  fs.writeFileSync(outputPath, srtDataNoAds)
}
```

One disadvantage is that it moves `typescript` to a dependency (was a devDependency before) because it is needed to do `tsc` on npm postinstall.